### PR TITLE
Support multiple jyutpings for one character

### DIFF
--- a/jyutping/dictionary.py
+++ b/jyutping/dictionary.py
@@ -2,12 +2,13 @@
 Dictionary
 """
 from __future__ import absolute_import
+from collections import defaultdict
 import os
 import io
 from jyutping import logger
 
-CHT_DICT = {}
-CHS_DICT = {}
+CHT_DICT = defaultdict(set)
+CHS_DICT = defaultdict(set)
 
 
 def load_dictionary():
@@ -24,8 +25,12 @@ def load_dictionary():
                 continue
             line = line.strip().split('\t')
             cht, chs, jyp = line
-            CHT_DICT[cht] = jyp
-            CHS_DICT[chs] = jyp
+            if '/' in jyp:
+                jyps = set(jyp.split('/'))
+            else:
+                jyps = set([jyp])
+            CHT_DICT[cht].update(jyps)
+            CHS_DICT[chs].update(jyps)
 
 
 if __name__ == '__main__':

--- a/jyutping/jyutping.py
+++ b/jyutping/jyutping.py
@@ -5,28 +5,30 @@ Convert Chinese characters to Jyutping.
 from __future__ import absolute_import
 from jyutping import dictionary
 
-def get_jyutping(characters):
+def get_jyutping(characters, multiple=False):
     """
     Convert Chinese characters to Jyutping.
     @return an array of Jyutping for each character.
     """
     result = []
     for ch in characters:
-        result.append(search_single(ch))
+        result.append(search(ch, multiple))
     return result
 
 
-def search_single(character):
-    if len(dictionary.CHS_DICT) == 0 or len(dictionary.CHT_DICT) == 0:
+def search(character, multiple=False):
+    if not dictionary.CHS_DICT or not dictionary.CHT_DICT:
         dictionary.load_dictionary()
-    jyp = dictionary.CHS_DICT.get(character) or dictionary.CHT_DICT.get(character)
-    if jyp and '/' in jyp:
-        jyp = jyp.split('/')
-    return jyp
+    jyupings = dictionary.CHS_DICT.get(character, set()) | dictionary.CHT_DICT.get(character, set())
+    if multiple:
+        return jyupings
+    else:
+        return jyupings.pop() if jyupings else None
 
 
 def _test(word):
     print(word, get_jyutping(word))
+    print(word, get_jyutping(word, True))
 
 if __name__ == '__main__':
     _test('广东话')


### PR DESCRIPTION
Previously, this library only supports returning multiple jyutpings for items with `/`-separated annotations. However, many characters with multiple pronunciations appear as separate items in the dict TXT. This PR fixes the behavior for these multi-pronunciation characters, and adds an option to choose between returning a single (random) pronunciation or multiple pronunciations as a set.

Example:
```python3
>>> import jyutping
>>> jyutping.get('广东话')
['gwong2', 'dung1', 'waa6']
>>> jyutping.get('广东话', multiple=True)
[{'gwong2'}, {'dung1'}, {'waa6', 'waa2'}]
```